### PR TITLE
Loss calculation should not permanently change shapes of logits and targets

### DIFF
--- a/bigram.py
+++ b/bigram.py
@@ -74,9 +74,7 @@ class BigramLanguageModel(nn.Module):
             loss = None
         else:
             B, T, C = logits.shape
-            logits = logits.view(B*T, C)
-            targets = targets.view(B*T)
-            loss = F.cross_entropy(logits, targets)
+            loss = F.cross_entropy(logits.view(B*T, C), targets.view(B*T))
 
         return logits, loss
 

--- a/gpt.py
+++ b/gpt.py
@@ -103,7 +103,7 @@ class MultiHeadAttention(nn.Module):
         out = self.dropout(self.proj(out))
         return out
 
-class FeedFoward(nn.Module):
+class FeedForward(nn.Module):
     """ a simple linear layer followed by a non-linearity """
 
     def __init__(self, n_embd):
@@ -126,7 +126,7 @@ class Block(nn.Module):
         super().__init__()
         head_size = n_embd // n_head
         self.sa = MultiHeadAttention(n_head, head_size)
-        self.ffwd = FeedFoward(n_embd)
+        self.ffwd = FeedForward(n_embd)
         self.ln1 = nn.LayerNorm(n_embd)
         self.ln2 = nn.LayerNorm(n_embd)
 
@@ -172,9 +172,7 @@ class GPTLanguageModel(nn.Module):
             loss = None
         else:
             B, T, C = logits.shape
-            logits = logits.view(B*T, C)
-            targets = targets.view(B*T)
-            loss = F.cross_entropy(logits, targets)
+            loss = F.cross_entropy(logits.view(B*T, C), targets.view(B*T))
 
         return logits, loss
 


### PR DESCRIPTION
I want to talk about loss calculation in the forward method:
```python 
else:
    B, T, C = logits.shape
    logits = logits.view(B*T, C)
    targets = targets.view(B*T)
    loss = F.cross_entropy(logits, targets)

return logits, loss
```
the logic behind the change of shapes was explained in the video, but I don't understand why we change shapes permanently since it's only needed for the loss calculation only.

In the training loop:
```python 
    # sample a batch of data
    xb, yb = get_batch('train')

    # evaluate the loss
    logits, loss = model(xb, yb)
```
`xb` has shape of (B, T), `yb` has shape (B, T) and one might expect that  `logits` will have (B, T, ...) where in fact it's (B*T, ...).

The code works flawlessly simply because we don't do anything with logits, yet I think it's not the most desired behavior, especially considering that this is basically an educational code (or to be precise: an accompanying code for an educational video).

### Additional notes
The same could be done with transposing, but since we have batches we need to use [Tensor.mT](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.mT):
```python
else:
    loss = F.cross_entropy(logits.mT, targets)
```
Based on my benchmarks (on intel cpu) `.mT` is faster than `.view`, but `F.cross_entropy` works significantly faster with 2-D tensor rather than with 3-D, so in this case combo of 'view+F.cross_entropy' is preferable.


And this PR includes also one small renaming:
FeedFoward -> FeedFo**r**ward

I guess Foward is like Forward, but only if you have a thick British accent 😃 
 