### PR TITLE
adding option to use the bpe tokenizer tiktoken as mentioned in the lecture

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -27,6 +27,8 @@ with open('input.txt', 'r', encoding='utf-8') as f:
 if tokenizer == 'tiktoken':
     vocab_size = 50257 #from https://github.com/openai/tiktoken/blob/main/tiktoken_ext/openai_public.py
     bpt_tiktokenizer = tiktoken.get_encoding('gpt2')
+    encode = lambda s: [int(bpt_tiktokenizer.encode(c)[0]) for c in s] # encoder: take a string, output a list of integers
+    decode = lambda l: ''.join([bpt_tiktokenizer.decode([i]) for i in l]) # decoder: take a list of integers, output a string
 
 elif tokenizer == 'char':
     # here are all the unique characters that occur in this text

--- a/gpt.py
+++ b/gpt.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
+import tiktoken
 
 # hyperparameters
 batch_size = 64 # how many independent sequences will we process in parallel?
@@ -22,14 +23,21 @@ torch.manual_seed(1337)
 with open('input.txt', 'r', encoding='utf-8') as f:
     text = f.read()
 
-# here are all the unique characters that occur in this text
-chars = sorted(list(set(text)))
-vocab_size = len(chars)
-# create a mapping from characters to integers
-stoi = { ch:i for i,ch in enumerate(chars) }
-itos = { i:ch for i,ch in enumerate(chars) }
-encode = lambda s: [stoi[c] for c in s] # encoder: take a string, output a list of integers
-decode = lambda l: ''.join([itos[i] for i in l]) # decoder: take a list of integers, output a string
+tokenizer = 'char' # 'tiktoken' for openai bpe tokenizor or 'char' for character tokenizor
+
+if tokenizer == 'tiktoken':
+    vocab_size = 50257 #from https://github.com/openai/tiktoken/blob/main/tiktoken_ext/openai_public.py
+    bpt_tiktokenizer = tiktoken.get_encoding('gpt2')
+
+elif tokenizer == 'char':
+    # here are all the unique characters that occur in this text
+    chars = sorted(list(set(text)))
+    vocab_size = len(chars)
+    # create a mapping from characters to integers
+    stoi = { ch:i for i,ch in enumerate(chars) }
+    itos = { i:ch for i,ch in enumerate(chars) }
+    encode = lambda s: [stoi[c] for c in s] # encoder: take a string, output a list of integers
+    decode = lambda l: ''.join([itos[i] for i in l]) # decoder: take a list of integers, output a string
 
 # Train and test splits
 data = torch.tensor(encode(text), dtype=torch.long)

--- a/gpt.py
+++ b/gpt.py
@@ -15,6 +15,7 @@ n_embd = 384
 n_head = 6
 n_layer = 6
 dropout = 0.2
+tokenizer = 'char' # 'tiktoken' for openai bpe tokenizor or 'char' for character tokenizor
 # ------------
 
 torch.manual_seed(1337)
@@ -22,8 +23,6 @@ torch.manual_seed(1337)
 # wget https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt
 with open('input.txt', 'r', encoding='utf-8') as f:
     text = f.read()
-
-tokenizer = 'char' # 'tiktoken' for openai bpe tokenizor or 'char' for character tokenizor
 
 if tokenizer == 'tiktoken':
     vocab_size = 50257 #from https://github.com/openai/tiktoken/blob/main/tiktoken_ext/openai_public.py


### PR DESCRIPTION
tested it on down bad hyperparameters due to memory limitations and worked, the loss and number of parameters for both options are:

tiktoken:

0.452817 M parameters
step 0: train loss 10.8239, val loss 10.8242
step 500: train loss 8.5850, val loss 8.5881
step 1000: train loss 5.3027, val loss 5.3133
step 1500: train loss 3.6597, val loss 3.6863
step 2000: train loss 3.3955, val loss 3.4450
step 2500: train loss 3.3283, val loss 3.3641
step 3000: train loss 3.2395, val loss 3.2716
step 3500: train loss 3.1519, val loss 3.1619
step 4000: train loss 3.0349, val loss 3.0535
step 4500: train loss 2.9624, val loss 2.9659
step 4999: train loss 2.9048, val loss 2.9137

char:

0.001089 M parameters
step 0: train loss 4.1758, val loss 4.1754
step 500: train loss 3.4595, val loss 3.4740
step 1000: train loss 3.1641, val loss 3.1794
step 1500: train loss 2.9892, val loss 3.0016
step 2000: train loss 2.8817, val loss 2.8845
step 2500: train loss 2.8174, val loss 2.8264
step 3000: train loss 2.7864, val loss 2.7788
step 3500: train loss 2.7503, val loss 2.7482
step 4000: train loss 2.7327, val loss 2.7282
step 4500: train loss 2.7174, val loss 2.7107
step 4999: train loss 2.7026, val loss 2.6954

considering the magnitudes worth of increase in number of parameter for no final decrease in loss, its debatable whether its worthwhile to use it on low hyperparam settings at all, but could be worth for higher hyperparam settings as gpt2 and google(sentencepiece) uses it as mentioned in the lecture, or maybe its worth just for the sake of satisfying morbid curiosity