### PR TITLE
Minor correction in 'Add & Norm' logic in Block Class in gpt.py

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -131,8 +131,8 @@ class Block(nn.Module):
         self.ln2 = nn.LayerNorm(n_embd)
 
     def forward(self, x):
-        x = x + self.sa(self.ln1(x))
-        x = x + self.ffwd(self.ln2(x))
+        x = self.ln1(self.sa(x) + x)
+        x = self.ln2(self.ffwd(x) + x)
         return x
 
 class GPTLanguageModel(nn.Module):


### PR DESCRIPTION
Updating the forward function in Transformer block.

The change is simple, but still trying my best to explain below:

As per original paper: In 'Add & Norm' block of Transformer, Layer Norm is applied on top of => input/ residual and output of Self-attention. While in the current code, layer Norm is applied first & then added back to the input/ residual.