### PR TITLE
edit shape comments in `generate` method

### DIFF
--- a/bigram.py
+++ b/bigram.py
@@ -86,9 +86,9 @@ class BigramLanguageModel(nn.Module):
             # get the predictions
             logits, loss = self(idx)
             # focus only on the last time step
-            logits = logits[:, -1, :] # becomes (B, C)
+            logits = logits[:, -1, :] # becomes (B, vocab_size)
             # apply softmax to get probabilities
-            probs = F.softmax(logits, dim=-1) # (B, C)
+            probs = F.softmax(logits, dim=-1) # (B, vocab_size)
             # sample from the distribution
             idx_next = torch.multinomial(probs, num_samples=1) # (B, 1)
             # append sampled index to the running sequence

--- a/gpt.py
+++ b/gpt.py
@@ -186,9 +186,9 @@ class GPTLanguageModel(nn.Module):
             # get the predictions
             logits, loss = self(idx_cond)
             # focus only on the last time step
-            logits = logits[:, -1, :] # becomes (B, C)
+            logits = logits[:, -1, :] # becomes (B, vocab_size)
             # apply softmax to get probabilities
-            probs = F.softmax(logits, dim=-1) # (B, C)
+            probs = F.softmax(logits, dim=-1) # (B, vocab_size)
             # sample from the distribution
             idx_next = torch.multinomial(probs, num_samples=1) # (B, 1)
             # append sampled index to the running sequence


### PR DESCRIPTION
Quick comments editing...
After the `forward` pass of the model, the `logits` have shape `(B, vocab_size)` because they are passed into `lm_head` where `self.lm_head = nn.Linear(n_embd, vocab_size)`.
Same for `probs` which is just a softmax of `logits`.
For bigram `C == vocab_size` anyway, but it feels more correct 😆.
BTW, thanks for your amazing videos! 🙂